### PR TITLE
ci(lint): add job to report new dependencies added

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,3 +41,12 @@ jobs:
 
       - name: Lint yaml files
         uses: ibiqlik/action-yamllint@v3.1.0
+
+  report_new_dependencies:
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    steps:
+      - name: Check for new dependencies
+        uses: hiwelo/new-dependencies-action@1.0.1
+        with:
+          token: ${{ secrets.OKP4_TOKEN }}


### PR DESCRIPTION
## Purpose

This PRs add a new job (in the `lint` workflow) to report added or updated dependencies as a comment (posted by @bot-anik) in a pull request.

<img width="690" alt="image" src="https://user-images.githubusercontent.com/9574336/158072676-a26b7f7a-54d1-4265-b85f-9f4981e96f82.png">

## Rationale

Well, adding or removing dependencies is never trivial, and it can have serious consequences that should be discussed between maintainers. Posting a summary comment can help us make sure we don't miss the dependency change.

## Links

- [actions/highlight-new-npm-dependencies](https://github.com/marketplace/actions/highlight-new-npm-dependencies)