### PR TITLE
chore: make yarn & node engines compatible with version instead of equivalent to

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "url": "https://github.com/okp4/eslint-config-okp4/issues"
   },
   "engines": {
-    "node": "~16.14.0",
-    "yarn": "~1.22.17"
+    "node": "^16.14.0",
+    "yarn": "^1.22.17"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
This PR makes the `yarn` and `node` engines compatible with the declared version instead of equivalent to.