### PR TITLE
chore: add .idea folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 node_modules
+.idea/


### PR DESCRIPTION
This PR ensures that `.idea` folder that contains `idea` configuration files is correctly ignored from `git`.