### PR TITLE
ci(release): allow release non functional changes

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -2,7 +2,20 @@ branches:
   - main
 
 plugins:
-  - "@semantic-release/commit-analyzer"
+  - - "@semantic-release/commit-analyzer"
+    - releaseRules:
+        - type: build
+          release": patch
+        - type: ci
+          release": patch
+        - type: docs
+          release": patch
+        - type: style
+          release": patch
+        - type: refactor
+          release": patch
+        - type: chore
+          release": patch
   - "@semantic-release/release-notes-generator"
   - - "@semantic-release/changelog"
     - changelogFile: CHANGELOG.md


### PR DESCRIPTION
Non functional changes commit of the following types will now trigger a release:
- build
- ci
- docs
- style
- refactor
- chore

The released version will be a patch.