### PR TITLE
ci(release): properly configure conventional commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
             @semantic-release/changelog
             @semantic-release/git
             @semantic-release/npm
+          extends: |
+            conventional-changelog-conventionalcommits
         env:
           GITHUB_TOKEN: ${{ secrets.OKP4_TOKEN }}
           GIT_AUTHOR_NAME: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }}

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -3,6 +3,7 @@ branches:
 
 plugins:
   - - "@semantic-release/commit-analyzer"
+    - preset: conventionalcommits
     - releaseRules:
         - type: build
           release: patch
@@ -16,7 +17,8 @@ plugins:
           release: patch
         - type: chore
           release: patch
-  - "@semantic-release/release-notes-generator"
+  - - "@semantic-release/release-notes-generator"
+    - preset: conventionalcommits
   - - "@semantic-release/changelog"
     - changelogFile: CHANGELOG.md
       changelogTitle: "# ØKP4 eslint-config changelog"


### PR DESCRIPTION
Use the `conventionalcommits` preset of semantic release.