### PR TITLE
Feat/bump node 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup node environment (for building)
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 18.18
 
       - name: Build
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup node environment (for publishing)
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 18.18
           registry-url: "https://npm.pkg.github.com"
           scope: "@okp4"
 
@@ -67,7 +67,7 @@ jobs:
       - name: Setup node environment (for publishing)
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 18.18
           registry-url: "https://registry.npmjs.org"
           scope: "@okp4"
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/okp4/eslint-config-okp4/issues"
   },
   "engines": {
-    "node": "^16.14.0",
+    "node": "^18.18.0",
     "yarn": "^1.22.17"
   },
   "files": [


### PR DESCRIPTION
According to https://github.com/okp4/eslint-config-okp4/pull/137#issuecomment-1730025890, remake the previously merged https://github.com/okp4/eslint-config-okp4/pull/137 which has been reverted by removing the underlying commits in the `main` branch.

As the change here is breaking by nature, this PR retake the same changes adding the breaking change marker used by semantic release to forge the next version number, and also mention it in the changelog.